### PR TITLE
Add timestamp output (relative by default, switchable to absolute)

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -20,6 +20,8 @@ include_package_data = true
 install_requires =
     sopel>=7.1,<9
     requests
+    # can be rewritten without once we're Sopel 8+ (i.e. Python 3.8+)
+    pytz
 
 [options.entry_points]
 sopel.plugins =


### PR DESCRIPTION
Uses the channel timezone and time format if in absolute mode.

Will need refactoring to drop the `pytz` requirement when dropping support for Sopel 7.x (meaning Python 2); `datetime.timezone` doesn't exist until Python 3.

Closes #1.