### PR TITLE
Slight improvements for missing items & empty reverse-search results

### DIFF
--- a/sopel_hackernews/__init__.py
+++ b/sopel_hackernews/__init__.py
@@ -68,7 +68,7 @@ def reverse_hn(bot, trigger):
 
         query = bot.memory['last_seen_url'][trigger.sender]
 
-    results = requests.get("https://hn.algolia.com/api/v1/search?query={}".format(query)).json()
+    results = requests.get('https://hn.algolia.com/api/v1/search?query={}'.format(query)).json()
 
     try:
         item = results['hits'][0]
@@ -84,7 +84,7 @@ def reverse_hn(bot, trigger):
             )
         )
     except (IndexError, KeyError, TypeError):
-        bot.say("No HN discussion found for that link.")
+        bot.say('No HN discussion found for that link.')
 
 
 @plugin.url(HN_PATTERN)
@@ -95,7 +95,7 @@ def forward_hn(bot, trigger):
     ).json()
 
     if item is None:
-        bot.say("Item {} not found.".format(trigger.group('ID')))
+        bot.say('Item {} not found.'.format(trigger.group('ID')))
         return
 
     if item['type'] == 'comment':

--- a/sopel_hackernews/__init__.py
+++ b/sopel_hackernews/__init__.py
@@ -83,8 +83,8 @@ def reverse_hn(bot, trigger):
                 hn_link='https://news.ycombinator.com/item?id=' + item['objectID'],
             )
         )
-    except:
-        bot.say("No HN discussion found")
+    except (IndexError, KeyError, TypeError):
+        bot.say("No HN discussion found for that link.")
 
 
 @plugin.url(HN_PATTERN)
@@ -95,7 +95,7 @@ def forward_hn(bot, trigger):
     ).json()
 
     if item is None:
-        bot.say("No HN item found.")
+        bot.say("Item {} not found.".format(trigger.group('ID')))
         return
 
     if item['type'] == 'comment':


### PR DESCRIPTION
Reverse lookup should only `except` on expected exception types, so any unexpected case will announce itself through a traceback.

Improved messaging to include the item ID if fetching an item returns `null`, possibly helping the person who pasted the link to notice any accidentally added characters and retry.