### PR TITLE
Bail out with a friendly error on deleted items

### DIFF
--- a/sopel_hackernews/__init__.py
+++ b/sopel_hackernews/__init__.py
@@ -98,6 +98,10 @@ def forward_hn(bot, trigger):
         bot.say('Item {} not found.'.format(trigger.group('ID')))
         return
 
+    if item.get('deleted'):
+        bot.say('Item {} is a deleted {}.'.format(item['id'], item['type']))
+        return
+
     if item['type'] == 'comment':
         bot.say(
             'Comment{dead} by {author} ({when}): {text}'.format(


### PR DESCRIPTION
Included output from 8a933e3535ec76ed079e623bf19d40e1fb201dd7 (`Sopel`) for comparison with this patch (`SopelTest`).

```irc
<dgw> https://news.ycombinator.com/item?id=38344153
<Sopel> Unexpected KeyError ('url') from dgw. Message was: https://news.ycombinator.com/item?id=38344153
<SopelTest> [Hacker News] Item 38344153 is a deleted story.
```

It's possible to include when the deleted item was _submitted_ in the output (`time` field), but that's dubiously useful.