### PR TITLE
Basic poll support

### DIFF
--- a/sopel_hackernews/__init__.py
+++ b/sopel_hackernews/__init__.py
@@ -139,3 +139,17 @@ def forward_hn(bot, trigger):
             ),
             truncation=(' ' + urlparse(url).hostname) if url else ' …',
         )
+    elif item['type'] == 'poll':
+        url = item.get('url')
+
+        bot.say(
+            '🗳️ {title} | ✅ {choice_count} | 👤 {author} | 📆 {when} | ▲ {score} | 🗨️ {comments}'.format(
+                title=item['title'],
+                choice_count=len(item.get('parts', [])),
+                author=item.get('by') or '(nobody)',
+                when=get_formatted_timestamp(item['time'], trigger.sender, bot),
+                score=item['score'],
+                comments=item['descendants'],
+            ),
+            truncation=' […]',
+        )


### PR DESCRIPTION
Showing just the number of poll options is simplest, since the HN API includes that value directly (as "parts").

Getting the label for each poll option would make the output quite a bit longer at the cost of one additional API request per choice. (That seems excessive, so I'm not doing it. At least not yet.)
