### PR TITLE
Parse basic formatting in HN comments

### DIFF
--- a/sopel_hackernews/formatting.py
+++ b/sopel_hackernews/formatting.py
@@ -1,0 +1,46 @@
+"""sopel-hackernews formatting module
+
+Part of sopel-hackernews, a Hacker News plugin for Sopel.
+"""
+from __future__ import annotations
+
+from html import unescape
+from html.parser import HTMLParser
+
+from sopel.formatting import CONTROL_ITALIC, CONTROL_MONOSPACE
+
+
+class HNParser(HTMLParser):
+    """Custom HTML parser to convert HN's wacky HTML to IRC-formatted text."""
+
+    def __init__(self):
+        super().__init__()
+        self.result = []
+
+    def handle_starttag(self, tag, attrs):
+        if tag == 'p':
+            # note: HN doesn't close <p> tags
+            # also note: HN doesn't put a <p> before the first paragraph
+            self.result.append(' \N{RETURN SYMBOL} ')
+        elif tag =='i':
+            self.result.append(CONTROL_ITALIC)
+        elif tag == 'pre':
+            self.result.append(CONTROL_MONOSPACE)
+        # ignore other tags, e.g. <a> just wraps plaintext URLs so handle_data()
+        # will deal with those just fine
+
+    def handle_endtag(self, tag):
+        if tag == 'i':
+            self.result.append(CONTROL_ITALIC)
+        elif tag == 'pre':
+            self.result.append(CONTROL_MONOSPACE)
+
+    def handle_data(self, data):
+        data = data.replace('\n', ' \N{RETURN SYMBOL} \n')
+        self.result.extend([line.lstrip() for line in data.splitlines()])
+
+    def get_data(self):
+        """Get the parsed data as a single string."""
+        out = ''.join(self.result)
+        out = unescape(out).replace('\n', ' \N{RETURN SYMBOL} ')
+        return out

--- a/sopel_hackernews/formatting.py
+++ b/sopel_hackernews/formatting.py
@@ -6,8 +6,12 @@ from __future__ import annotations
 
 from html import unescape
 from html.parser import HTMLParser
+import re
 
 from sopel.formatting import CONTROL_ITALIC, CONTROL_MONOSPACE
+
+
+CONSECUTIVE_SPACES_RE = re.compile(r' {2,}')
 
 
 class HNParser(HTMLParser):
@@ -49,4 +53,4 @@ class HNParser(HTMLParser):
         """Get the parsed data as a single string."""
         out = ''.join(self.result)
         out = unescape(out).replace('\n', ' \N{RETURN SYMBOL} ')
-        return out
+        return CONSECUTIVE_SPACES_RE.sub(' ', out)

--- a/sopel_hackernews/formatting.py
+++ b/sopel_hackernews/formatting.py
@@ -16,6 +16,7 @@ class HNParser(HTMLParser):
     def __init__(self):
         super().__init__()
         self.result = []
+        self.single_newline_as_space = True
 
     def handle_starttag(self, tag, attrs):
         if tag == 'p':
@@ -26,6 +27,7 @@ class HNParser(HTMLParser):
             self.result.append(CONTROL_ITALIC)
         elif tag == 'pre':
             self.result.append(CONTROL_MONOSPACE)
+            self.single_newline_as_space = False
         # ignore other tags, e.g. <a> just wraps plaintext URLs so handle_data()
         # will deal with those just fine
 
@@ -34,9 +36,13 @@ class HNParser(HTMLParser):
             self.result.append(CONTROL_ITALIC)
         elif tag == 'pre':
             self.result.append(CONTROL_MONOSPACE)
+            self.single_newline_as_space = True
 
     def handle_data(self, data):
-        data = data.replace('\n', ' \N{RETURN SYMBOL} \n')
+        if self.single_newline_as_space:
+            data = data.replace('\n', ' ')
+        else:
+            data = data.replace('\n', ' \N{RETURN SYMBOL} \n')
         self.result.extend([line.lstrip() for line in data.splitlines()])
 
     def get_data(self):


### PR DESCRIPTION
Mostly correct. Handles italics (converted to IRC italics), `<pre>` blocks (converted to IRC monospace), and drops `<a>` tags. Converts `<p>` to a visual newline indicator, and still unescapes HTML entities for display.

Certain uses of `\n` are a little strange, like https://news.ycombinator.com/item?id=38472130 (one of the examples from #3) will output a visual newline indicator even though the HN site just displays a single space.