### PR TITLE
Spit and polish for 0.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,19 @@ Releases are hosted on PyPI, so after installing Sopel, all you need is `pip`:
 $ pip install sopel-hackernews
 ```
 
+## Configuring
+
+`sopel-hackernews` supports Sopel's config wizard:
+
+```shell
+$ sopel-plugins configure hackernews
+```
+
+Available settings are as follows:
+
+- `relative_timestamps` — whether timestamps will be "humanized" like "2 days, 3
+  hours ago" (the default) or shown as absolute values
+
 ## Usage
 
 Links to Hacker News items are expanded automatically.

--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ You can search for a link on HN using the `.rhn` command:
 
 ## Credits
 
-Loosely based on [dasu's `hn.py` module](https://github.com/dasu/syrup-sopel-modules/blob/8f644ba4b4cdda06200f18a36959796ae7979fb6/hn.py),
-which was licensed as "literally do whatever you want, i'm not liable for
-anything lol". Thank you for the springboard!
+Loosely based on [dasu's `hn.py` module][dasu-hn.py], which was licensed as
+"literally do whatever you want, i'm not liable for anything lol". Thank you for
+the springboard!
+
+[dasu-hn.py]: https://github.com/dasu/syrup-sopel-modules/blob/8f644ba4b4cdda06200f18a36959796ae7979fb6/hn.py

--- a/sopel_hackernews/__init__.py
+++ b/sopel_hackernews/__init__.py
@@ -24,11 +24,22 @@ PLUGIN_PREFIX = '[Hacker News] '
 
 
 class HackerNewsSection(types.StaticSection):
-    relative_timestamps = types.BooleanAttribute('relative_timestamps', default=True)
+    relative_timestamps = types.BooleanAttribute(
+        'relative_timestamps',
+        default=True,
+    )
 
 
 def setup(bot):
     bot.settings.define_section('hackernews', HackerNewsSection)
+
+
+def configure(settings):
+    settings.define_section('hackernews', HackerNewsSection)
+    settings.hackernews.configure_setting(
+        'relative_timestamps',
+        'Use relative timestamps for HN items?',
+    )
 
 
 def clean_hn_text(text):


### PR DESCRIPTION
Biggest thing here so far is making `sopel-hackernews` support `sopel-plugins configure`, which wasn't there before. The `relative_timestamps` setting probably doesn't need much explanation, but for completeness… it's there in the readme.