### PR TITLE
formatting: skip lstrip() of data lines

### DIFF
--- a/sopel_hackernews/formatting.py
+++ b/sopel_hackernews/formatting.py
@@ -47,7 +47,7 @@ class HNParser(HTMLParser):
             data = data.replace('\n', ' ')
         else:
             data = data.replace('\n', ' \N{RETURN SYMBOL} \n')
-        self.result.extend([line.lstrip() for line in data.splitlines()])
+        self.result.extend(data.splitlines())
 
     def get_data(self):
         """Get the parsed data as a single string."""


### PR DESCRIPTION
With each line lstrip()-ed, sometimes necessary spaces would be removed (such as after a closing </a> tag), and quirks of the API response would get turned into newline indicators.

Having retested all examples I could find in the issues/PRs related to "parsing" the HTML/formatting of comments, this simpler approach wins.
